### PR TITLE
implement Send for Stream (closes #6)

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -9,6 +9,8 @@ pub struct Stream {
     pub(crate) state: *mut coqui_stt_sys::StreamingState,
 }
 
+unsafe impl Send for Stream {}
+
 impl Drop for Stream {
     #[inline]
     fn drop(&mut self) {


### PR DESCRIPTION
This is almost entirely untested, and I haven't confirmed that libstt claims to be threadsafe, but it does seem likely.