### PR TITLE
Remove outdated lines from doc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,9 +10,6 @@
 //! No features are enabled by default.
 //!
 //! * `raw-bindings`: exposes the [`coqui-stt-sys`](coqui_stt_sys) crate at the root under the same name.
-//! * `threadsafe-streams`: exposes a [`ThreadSafeStream`](crate::ThreadSafeStream) object at the root.
-//! * `async-streams`: exposes async bindings to `ThreadSafeStream`.
-//!   Enables [`flume`](flume)'s `async` feature.
 
 #[macro_use]
 mod helpers;


### PR DESCRIPTION
Seems like the following features were removed in this [commit](https://github.com/tazz4843/coqui-stt/commit/e534a5d7a4d8201611e5fcc22d1d0d2c453f62b9):

`threadsafe-streams`
`async-streams`

So, I have removed the mentions from the docs.