### PR TITLE
Remove unsafe keyword and use collect() instead

### DIFF
--- a/src/candidate_transcript.rs
+++ b/src/candidate_transcript.rs
@@ -15,7 +15,7 @@ impl CandidateTranscript {
     #[must_use]
     pub fn tokens(&self) -> &[TokenMetadata] {
         let data = self.0.tokens.cast();
-        let len = self.0.num_tokens as usize;
+        let len = self.num_tokens() as usize;
 
         // SAFETY: the inner objects will always be of type TokenMetadata,
         // and the length will always be proper
@@ -44,14 +44,10 @@ impl CandidateTranscript {
     #[inline]
     #[must_use]
     pub fn to_owned(&self) -> OwnedCandidateTranscript {
-        let mut tokens = Vec::with_capacity(self.0.num_tokens as usize);
-        for token in self.tokens() {
-            tokens.push(token.to_owned());
-        }
-
+        let tokens = self.tokens().iter().map(|t| t.to_owned()).collect();
         OwnedCandidateTranscript {
             tokens,
-            confidence: self.0.confidence,
+            confidence: self.confidence(),
         }
     }
 }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -53,13 +53,7 @@ impl Metadata {
     #[inline]
     #[must_use]
     pub fn to_owned(&self) -> OwnedMetadata {
-        // SAFETY: this object will never be constructed with a null pointer
-        let mut transcripts = Vec::with_capacity(unsafe { *self.0 }.num_transcripts as usize);
-        for transcript in self.transcripts() {
-            transcripts.push(transcript.to_owned());
-        }
-
-        OwnedMetadata(transcripts)
+        OwnedMetadata(self.transcripts().iter().map(|t| t.to_owned()).collect())
     }
 }
 


### PR DESCRIPTION
This PR removes the use of `unsafe` keyword and collects the `OwnedMetadata` and `OwnedCandidateTranscript` in a bit more idiomatic way.