### PR TITLE
fix type conversion

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -72,7 +72,7 @@ impl Model {
         // both of which have been checked
         let retval = unsafe {
             coqui_stt_sys::STT_CreateModelFromBuffer(
-                buffer.as_ptr().cast::<i8>(),
+                buffer.as_ptr().cast::<std::os::raw::c_char>(),
                 buffer.len() as c_uint,
                 std::ptr::addr_of_mut!(state),
             )
@@ -154,7 +154,7 @@ impl Model {
     fn _enable_external_scorer_from_buffer(&mut self, buffer: &[u8]) -> crate::Result<()> {
         handle_error!(coqui_stt_sys::STT_EnableExternalScorerFromBuffer(
             self.0,
-            buffer.as_ptr().cast::<i8>(),
+            buffer.as_ptr().cast::<std::os::raw::c_char>(),
             buffer.len() as c_uint
         ))
     }


### PR DESCRIPTION
coqui-stt could not be compiled for the target `armv7-unknown-linux-gnueabihf` because `STT_CreateModelFromBuffer` requires an argument whose type is `std::os::raw::c_char` which is not `i8` on the previously mentioned target. Casting the argument to `std::os::raw::c_char` before passing it will make the library more os-agnostic.